### PR TITLE
Fixes output TPTP syntax errors in ppTransTPTP

### DIFF
--- a/PPTransTPTP/CMakeLists.txt
+++ b/PPTransTPTP/CMakeLists.txt
@@ -29,3 +29,4 @@ target_link_libraries(ppTransTPTP
         -Bdynamic Qt5::Core Qt5::Xml)
 
 add_executable(TPTPfilter TPTPfilter.cpp)
+target_link_libraries(TPTPfilter -static)

--- a/PPTransTPTP/decomposition.cpp
+++ b/PPTransTPTP/decomposition.cpp
@@ -21,8 +21,8 @@
 #include "exprDesc.h"
 #include "predDesc.h"
 
-inline bool isProduct(const BType &ty){
-    return (ty.getKind() == BType::Kind::ProductType);
+inline bool isProduct(const BType &ty) {
+  return (ty.getKind() == BType::Kind::ProductType);
 }
 
 inline bool isStruct(const BType &ty){
@@ -303,7 +303,7 @@ void decomp::decompose(DContext &ctx, Pred &p){
             {
                 auto &q = p.toForall();
                 auto vars = ctx.push_vars(q.vars);
-                decompose(ctx,q.body);
+                decompose(ctx, q.body);
                 ctx.pop_vars();
                 return;
             }


### PR DESCRIPTION
The output of ppTransTPTP was not always compliant with the checks performed by TPTP4X. This commit fixes several sources of non-compliance.

Restriction: ppTransTPTP does not handle correctly struct and records.
